### PR TITLE
docs: migrate docs from https://prismic.io/docs to Markdown files

### DIFF
--- a/docs/01-query-the-api/01-how-to-query-the-api.md
+++ b/docs/01-query-the-api/01-how-to-query-the-api.md
@@ -1,0 +1,181 @@
+# Query the API
+
+A productive way to build pages with Prismic is to follow an iterative cycle of **defining** fields for your Custom Types, **querying** its content, and **integrating** it into templates.
+
+Queries allow you to retrieve content to be displayed on your pages.
+
+## Query predicates
+
+Queries in Prismic are based on predicates. Some predicates apply to any Custom Type, and some are field-specific. You can also combine multiple predicates to express your query.
+
+Here is an example query for retrieving a basic page through its UID:
+
+```cs
+// String uid comes from the querystring
+Document document = api.GetByUID("basic-page", uid);
+```
+
+The following example retrieves all blog posts:
+
+```cs
+Response response = api.query(Predicates.At("document.type", "blog-post"))
+   .PageSize(10)
+   .Orderings("my.blog-post.date desc")
+   .Submit();
+```
+
+A full-text search on all blog posts is done combining two predicates:
+
+```cs
+Response response = api.Query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.Fulltext("document", terms) // terms is a String
+).Submit();
+IList<Document> documents = response.Results;
+```
+
+> **Pagination of API Results**
+>
+> When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination below with the query options.
+
+## Predicates reference
+
+### At(path, value)
+
+The `At` operator is the equality operator, checking that the fragment matches the described value exactly. <br/>It takes a value for a field or an array (only for tags).
+
+| Property                       | Description                                                    |
+| ------------------------------ | -------------------------------------------------------------- |
+| <strong>path</strong><br/>     | <p>document.type<br />document.tags<br />my.{type}.{field}</p> |
+| <strong>value</strong><br/>    | <p>single value</p>                                            |
+| <strong>examples</strong><br/> | <pre>At(&quot;document.type&quot;, &quot;product&quot;)        |
+
+At(&quot;document.tags&quot;, [&quot;Macaron&quot;, &quot;Cupcake&quot;])
+At(&quot;my.articles.gender&quot;, &quot;male&quot;)</pre>|
+
+### Not(path, value)
+
+The `Not` operator is the different operator, checking that the fragment doesn't match the described value exactly. <br/>It takes a value for a field.
+
+| Property                      | Description                                                    |
+| ----------------------------- | -------------------------------------------------------------- |
+| <strong>path</strong><br/>    | <p>document.type<br />my.{type}.{field}</p>                    |
+| <strong>value</strong><br/>   | <p>single value</p>                                            |
+| <strong>example</strong><br/> | <pre>Not(&quot;document.type&quot;, &quot;product&quot;)</pre> |
+
+### Any(path, values)
+
+The `Any` operator takes an array of strings as a value. It works exactly the same way as the at operator, but checks whether the fragment matches either one of the values in the array. You can use it with all fragment types.
+
+| Property                      | Description                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/>    | <p>document.type</p><p>my.{type}.{field}</p>                                            |
+| <strong>values</strong><br/>  | <p>array of values</p>                                                                  |
+| <strong>example</strong><br/> | <pre>Any(&quot;document.type&quot;, [&quot;product&quot;, &quot;blog-post&quot;])</pre> |
+
+### In(path, values)
+
+The `In`\*\* \*\*operator is used to retrieve documents using an Array of IDs or UIDs. It returns the documents in the same order as the passed Array.
+
+| Property                      | Description                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| <strong>path</strong><br/>    | <p>document.type</p><p>my.{type}.{field}</p>                                |
+| <strong>values</strong><br/>  | <p>array of values</p>                                                      |
+| <strong>example</strong><br/> | <pre>In(&quot;document.uid, [&quot;myuid1&quot;, &quot;myuid2&quot;])</pre> |
+
+### Fulltext(path, value)
+
+The `Fulltext` operator provides two capabilities: either you want to check if a certain string is anywhere inside a document (this is what you should use to make your project's search engine feature), or if the string is contained inside a specific document's structured text fragment. In the example, you want to search the term `music` in the document
+
+If you want to check in a given structured text fragment, you will use something like the second example.
+
+| Property                                                        | Description                                            |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| <strong>path</strong><br/>                                      | <p>document</p><p>my.{type}.{field}</p>                |
+| <strong>value</strong><br/>                                     | <p>search terms</p>                                    |
+| <strong>example</strong><br/>                                   | <pre>Fulltext(&quot;document&quot;, &quot;music&quot;) |
+| Fulltext(&quot;my.product.title&quot;, &quot;music&quot;)</pre> |
+
+### Has(path)
+
+The `Has` operator check whether a fragment has a value.
+
+| Property                      | Description                                |
+| ----------------------------- | ------------------------------------------ |
+| <strong>path</strong><br/>    | <p>my.{type}.{field}</p>                   |
+| <strong>example</strong><br/> | <pre>Has(&#39;my.product.price&#39;)</pre> |
+
+### Missing(path)
+
+The `Missing` operator check if a fragment doesn't have a value. Note that the missing operator will restrict the results to the type implied in the fragment path.
+
+| Property                      | Description                                    |
+| ----------------------------- | ---------------------------------------------- |
+| <strong>path</strong><br/>    | <p>my.{type}.{field}</p>                       |
+| <strong>example</strong><br/> | <pre>Missing(&#39;my.product.price&#39;)</pre> |
+
+### Similar(id,value)
+
+The `Similar` operator takes the ID of a document and returns a list of documents whose contents are similar. This allows to build an automated content discovery feature (for instance, a "Related posts" block) at almost no cost.
+
+| Property                          | Description                                                                                     |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| <strong>id</strong><br/>          | <p>document ID</p>                                                                              |
+| <strong>value</strong><br/>number | <p>the maximum count of documents that a term may appear in to be still considered relevant</p> |
+| <strong>example</strong><br/>     | <pre>similar(&quot;VkRmhykAAFA6PoBj&quot;, 10)</pre>                                            |
+
+## Predicate options
+
+### PageSize(value)
+
+The PageSize options define the maximum of documents that the API will return for your query. Default is 20, max is 100.
+
+| Property                    | Description      |
+| --------------------------- | ---------------- |
+| <strong>value</strong><br/> | <p>page size</p> |
+|                             | <p></p>          |
+
+### Page(value)
+
+The page options define the pagination for the result of your query. Defaults to "1", corresponding to the first page.
+
+| Property                    | Description       |
+| --------------------------- | ----------------- |
+| <strong>value</strong><br/> | <p>page index</p> |
+|                             | <p></p>           |
+
+### Orderings(values)
+
+Order result by fields. You can specify as many fields as you want, in order to address all of the documents you are querying or if you have the same value on a given field. Use "desc" next to the field name, to order it from greatest to lowest.
+
+| Property                     | Description   |
+| ---------------------------- | ------------- |
+| <strong>values</strong><br/> | <p>fields</p> |
+|                              | <p></p>       |
+
+### After(value)
+
+Query documents after a specific document. By reversing the ordering, you can query for previous documents. Useful when creating navigation for a blog.
+
+| Property                    | Description        |
+| --------------------------- | ------------------ |
+| <strong>value</strong><br/> | <p>document id</p> |
+|                             | <p></p>            |
+
+### FetchLinks(values)
+
+Additional fields to retrieve in LinkDocument fragments. The LinkDocument can then be queried like a Document. Note that this only works with basic fields such as Text, Number or Date. It is not possible to retrieve StructuredText fragments from linked document using this field.
+
+| Property                    | Description   |
+| --------------------------- | ------------- |
+| <strong>value</strong><br/> | <p>fields</p> |
+|                             | <p></p>       |
+
+### Fetch(values)
+
+fetch only specific fields
+
+| Property                    | Description               |
+| --------------------------- | ------------------------- |
+| <strong>value</strong><br/> | <p>fields to retrieve</p> |
+|                             | <p></p>                   |

--- a/docs/01-query-the-api/02-query-by-uid.md
+++ b/docs/01-query-the-api/02-query-by-uid.md
@@ -1,0 +1,34 @@
+# Query by UID with .NET
+
+This page shows how to query for a certain document by its UID.
+
+## Using the GetByUID Method
+
+The UID is unique within a custom type; documents of different types can have the same UID. This is why we add the API ID value of "page" below.
+
+```cs
+// UID is a string
+Document document = await api.GetByUID("page", uid);
+```
+
+## Preventing duplicate content
+
+When querying a document by UID, older values will also return your document. This ensure that existing links are not broken when the UID is changed.
+
+For better search engines ranking (SEO), you may want to redirect old URLs to the latest URL rather than serving the same content on both old and new:
+
+```cs
+// Using MVC.NET
+public async Task<ActionResult> Detail(string uid)
+{
+    var api = await prismic.Api.Get(endpoint);
+    var document = await api.GetByUID("page", uid);
+    if (document == null) { // 404
+        return new HttpNotFoundResult("Page not found");
+    } else if (document.Uid != uid) { // 301
+        return RedirectToActionPermanent ("Detail", new { document.Uid });
+    } else { // 200
+        return View (new PrismicDocument (document));
+    }
+}
+```

--- a/docs/01-query-the-api/03-query-rich-text.md
+++ b/docs/01-query-the-api/03-query-rich-text.md
@@ -1,0 +1,29 @@
+# Query Rich Text with .NET
+
+## Retrieve content with full-text search
+
+Rich Text can be queried with a full-text predicate. Here is a full-text query on content of type "blog-post".
+
+```cs
+var response = await api.Query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.Fulltext("document", terms)
+).Submit();
+```
+
+## Orderings
+
+Structured text fields can be used for orderings. Only the first text block will be used.
+
+```cs
+var response = await api.Query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.Fulltext("document", terms)
+).Orderings("my.blog-post.title").Submit();
+```
+
+## Retrieving Additional Information
+
+To prevent having to perform multiple queries, you can use fetchLinks to retrieve fields from the linked documents. It can only be used on simple types such as Text, Date, Timestamp and Number.
+
+It works for links within StructuredText just like link fragments. Usage is detailed on the [Query Links](../01-query-the-api/05-query-links.md) page.

--- a/docs/01-query-the-api/04-fulltext-search.md
+++ b/docs/01-query-the-api/04-fulltext-search.md
@@ -1,0 +1,17 @@
+# Fulltext Search with .NET
+
+## Perform a full-text search
+
+All text content is indexed when you perform a full-text search query.
+
+> Note that the fulltext search is not case sensitive.
+
+Here is an example that searches for terms in all the "blog-post" documents.
+
+```cs
+var response = await api.query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.Fulltext("document", terms) // terms is a String
+).Submit();
+IList<Document> documents = response.getResults();
+```

--- a/docs/01-query-the-api/05-query-links.md
+++ b/docs/01-query-the-api/05-query-links.md
@@ -1,0 +1,30 @@
+# Query Links with .NET
+
+## Query by the ID in a Link field
+
+The following example shows how to query by a Link field. This will return any document of the type "blog-post" in which the Link field "author" has the given "author" document ID.
+
+```cs
+Response response = api.Query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.At("my.blog-post.author", authorDocId)
+).Submit();
+```
+
+## Retrieving Additional Information
+
+To prevent having to perform multiple queries, you can use fetchLinks to retrieve fields from the linked documents. It can only be used on simple types such as Text, Date, Timestamp and Number. StructuredText are also supported but only the first bloc will be returned, as a Text type.
+
+```cs
+// Use fetchLinks to request additional fields in linked documents
+Response response = api.Query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.At("my.blog-post.author", authorDocId)
+).FetchLinks("author.name").Submit();
+
+Document document = response.Results.First;
+
+// Query linked document like a top-level document
+DocumentLink author = document.GetLink("blog-post.author");
+String authorName = author.GetText("author.name").Value;
+```

--- a/docs/01-query-the-api/06-query-by-date.md
+++ b/docs/01-query-the-api/06-query-by-date.md
@@ -1,0 +1,48 @@
+# Query by Date with .NET
+
+## Query by exact date
+
+Here we show how to query documents for a Date field equal to a specific date.
+
+```cs
+var response = await api.query(
+    Predicates.At("document.type", "blog-post"),
+    Predicates.At("my.blog-post.date",  new DateTime(2013, 8, 17, 0, 0))
+).Submit();
+```
+
+## Other time-based predicates
+
+Here are the other available Date query predicates.
+
+```cs
+Predicate dateBefore = Predicates.DateBefore("my.product.releaseDate", new DateTime(2014, 6, 1, 0, 0));
+Predicate dateAfter = Predicates.DateAfter("my.product.releaseDate", new DateTime(2014, 1, 1, 0, 0));
+Predicate dateBetween = Predicates.DateBetween("my.product.releaseDate", new DateTime(2014, 1, 1, 0, 0), new DateTime(2014, 6, 1, 0, 0));
+Predicate dayOfMonth = Predicates.DayOfMonth("my.product.releaseDate", 14);
+Predicate dayOfMonthAfter = Predicates.DayOfMonthAfter("my.product.releaseDate", 14);
+Predicate dayOfMonthBefore = Predicates.DayOfMonthBefore("my.product.releaseDate", 14);
+Predicate dayOfWeek = Predicates.DayOfWeek("my.product.releaseDate", Predicates.DayOfWeek.TUESDAY);
+Predicate dayOfWeekAfter = Predicates.DayOfWeekAfter("my.product.releaseDate", Predicates.DayOfWeek.WEDNESDAY);
+Predicate dayOfWeekBefore = Predicates.DayOfWeekBefore("my.product.releaseDate", Predicates.DayOfWeek.WEDNESDAY);
+Predicate month = Predicates.Month("my.product.releaseDate", Predicates.Month.JUNE);
+Predicate monthBefore = Predicates.MonthBefore("my.product.releaseDate", Predicates.Month.JUNE);
+Predicate monthAfter = Predicates.MonthAfter("my.product.releaseDate", Predicates.Month.JUNE);
+Predicate year = Predicates.Year("my.product.releaseDate", 2014);
+Predicate hour = Predicates.Hour("my.product.releaseDate", 12);
+Predicate hourBefore = Predicates.HourBefore("my.product.releaseDate", 12);
+Predicate hourAfter = Predicates.HourAfter("my.product.releaseDate", 12);
+```
+
+Time-related predicates are strict inequalities, in other words the date (or time) corresponding to the bounds is not returned in the results. If you need an inclusive query, you should offset the bound by one day (or second).
+
+## Orderings
+
+Date and timestamp fields can be used to order results.
+
+```cs
+var response = await api
+    .Query(Predicates.At("document.type", "blog-post"))
+    .Orderings("my.blog-post.date")
+    .Submit();
+```

--- a/docs/02-templating/01-uid.md
+++ b/docs/02-templating/01-uid.md
@@ -1,0 +1,11 @@
+# UID Templating with .NET
+
+The UID field is a unique identifier that can be used specifically to create SEO-friendly website URLs.
+
+## Retrieve the UID value
+
+Here’s how you would retrieve the uid value from the retrieved document object.
+
+```cs
+<p>Page uid: @Model.document.Uid</p>
+```

--- a/docs/02-templating/02-rich-text.md
+++ b/docs/02-templating/02-rich-text.md
@@ -1,0 +1,43 @@
+# Rich Text Templating with .NET
+
+## Output as HTML
+
+Since Rich Text is used for your text needs, we've included an `.AsHtml` method to transform it into HTML.
+
+The following example displays the "title" field of the blog post.
+
+```
+@Html.Raw(Model.document.GetStructuredText("blog-post.title").AsHtml(Model.Resolver))
+```
+
+This will display the rich text contained in the "body" field of the blog post.
+
+```
+@Html.Raw(Model.document.GetStructuredText("blog-post.body").AsHtml(Model.Resolver))
+```
+
+And finally this will display the "quote" field.
+
+```
+@Html.Raw(Model.document.GetStructuredText("blog-post.quote").AsHtml(Model.Resolver))
+```
+
+## Customize the HTML output
+
+You can customize the HTML output by passing an HTML serializer to the method as shown below.
+
+```
+// In your controller
+var serializer = prismic.HtmlSerializer.For ((elt, body) => {
+  if (elt is fragments.StructuredText.Hyperlink) {
+    var link = ((fragments.StructuredText.Hyperlink)elt).Link;
+    if (link is fragments.DocumentLink) {
+      var doclink = ((fragments.DocumentLink)link);
+      return String.Format("<a class=\"some-link\" href=\"{0}\">{1}</a>", resolver.Resolve(doclink), body);
+    }
+  }
+}
+
+// In Razor
+@Html.Raw(Model.document.GetStructuredText("blog-post.body").AsHtml(Model.Resolver, Model.Serializer))
+```

--- a/docs/02-templating/03-image.md
+++ b/docs/02-templating/03-image.md
@@ -1,0 +1,32 @@
+# Image Templating with .NET
+
+## Retrieve the image url
+
+Integrating an image is done by simply retrieving its URL and setting it in the template.
+
+The following integrates a page's illustration image field.
+
+```cs
+<!-- URL of the main view -->
+<img src="@Model.document.GetImage("page.illustration").Url"/>
+```
+
+## An image & a caption field
+
+Integrating the illustration with caption is also as straightforward:
+
+```cs
+<img src="@Model.document.GetImage("page.illustration").Url"/>
+<span class="image-caption">@Model.document.GetText("page.caption").AsText()}</span>
+```
+
+## A group of images
+
+For integrating a group of images (e.g. photo slide show in a page), you need to loop through the items:
+
+```cs
+@foreach (var imageWithCaption in Model.document.GetGroup("page.slide-show").GetDocs()) {
+  <img src="@imageWithCaption.GetImage("page.illustration").Url"/>
+  <span class="image-caption">@imageWithCaption.GetText("page.caption").AsText()</span>
+}
+```

--- a/docs/02-templating/04-slices.md
+++ b/docs/02-templating/04-slices.md
@@ -1,0 +1,19 @@
+# Slices Templating with .NET
+
+## Looping through slices
+
+Here is an example of integrating slices into a rich blog post.
+
+```cs
+@foreach (var slice in document.GetSliceZone("blog-post.body").Value) {
+  //- Render the right markup for a given slice type.
+  @switch (slice.SliceType) {
+    case "text": @: <div>@slice.Value.AsHtml(linkResolver)}</div>
+    break;
+    case "quote": @: <span class='block-quotation'>slice.Value</span>
+    break;
+    case "image-with-caption": @:
+      <p class='block-img'><img src="@slice.Value.Get("illustration").Url"></p>
+      <span class='image-label'>@slice.Value.get("caption").AsText()</span>
+}
+```

--- a/docs/02-templating/05-date-and-timestamp.md
+++ b/docs/02-templating/05-date-and-timestamp.md
@@ -1,0 +1,9 @@
+# Date Templating with .NET
+
+## Output as text
+
+Here is a simple example that hows how to add a Date field to your templates.
+
+```cs
+<input type="text" value="@Model.document.GetDate("blog-post.date").AsText()}"/>
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Prismic with .NET
+
+Documentation for `prismicio-community/dotnet-kit` is organized into the following sections.
+
+- [**Query the API**](./01-query-the-api)
+- [**Templating**](./02-templating)
+
+To learn more about [Prismic](https://prismic.io), including documentation for other languages and frameworks, see the main Prismic Documentation site.
+
+[**Prismic Documentation**](https://prismic.io/docs)


### PR DESCRIPTION
This PR adds a local docs directory with .NET documentation from https://prismic.io/docs. The content from the website has been converted to Markdown so no content is lost.

.NET documentation on https://prismic.io/docs will be removed. Documentation for this library should be updated as part of the repository.
